### PR TITLE
Restrict foreign keys to avoid cascade delete loops

### DIFF
--- a/Lizard/LizardDbContext.cs
+++ b/Lizard/LizardDbContext.cs
@@ -16,6 +16,9 @@ namespace Lizard
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            foreach (var fk in modelBuilder.Model.GetEntityTypes().SelectMany(t => t.GetForeignKeys()).Where(fk => !fk.IsOwnership && fk.DeleteBehavior == DeleteBehavior.Cascade))
+                fk.DeleteBehavior = DeleteBehavior.Restrict;
+
             modelBuilder.Entity<LogEntry>()
                 .Property(p => p.LogEntryID)
                 .UseIdentityColumn(long.MinValue, 1);


### PR DESCRIPTION
Foreign keys in the model were set to automatically cascade delete.

Now foreign keys are restrict row deletion in the model.

In future, this may be revised for cleanup features.