### PR TITLE
v1.2 Improvements

### DIFF
--- a/Lizard.Models/Lizard.Models.csproj
+++ b/Lizard.Models/Lizard.Models.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Copyright>Daniel James Thorne</Copyright>
     <PackageProjectUrl>https://github.com/rombethor/lizard</PackageProjectUrl>

--- a/Lizard.Monitor/Lizard.Monitor.csproj
+++ b/Lizard.Monitor/Lizard.Monitor.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Description>RabbitMQ message client for reporting to the Lizard service.</Description>
     <Copyright>Daniel James Thorne</Copyright>

--- a/Lizard/Controllers/VersionController.cs
+++ b/Lizard/Controllers/VersionController.cs
@@ -27,11 +27,5 @@ namespace Lizard.Controllers
             });
         }
 
-        [HttpPost("migrate")]
-        public IActionResult Migrate()
-        {
-            db.Database.Migrate();
-            return Ok();
-        }
     }
 }

--- a/Lizard/HealthChecks/ReadinessHealthCheck.cs
+++ b/Lizard/HealthChecks/ReadinessHealthCheck.cs
@@ -1,0 +1,26 @@
+﻿
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Lizard.HealthChecks
+{
+    public class ReadinessHealthCheck : IHealthCheck
+    {
+        IConfiguration configuration;
+        public ReadinessHealthCheck(IConfiguration _config)
+        {
+            configuration = _config;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlServer(configuration["database"]);
+            var db = new LizardDbContext(optionsBuilder.Options);
+            var pendingMigrations = await db.Database.GetPendingMigrationsAsync();
+            if (pendingMigrations.Any())
+                return HealthCheckResult.Unhealthy("Migrations pending");
+            return HealthCheckResult.Healthy("Ready");
+        }
+    }
+}

--- a/Lizard/Lizard.csproj
+++ b/Lizard/Lizard.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileTag>lizard</DockerfileTag>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <RepositoryUrl>https://github.com/rombethor/lizard</RepositoryUrl>
   </PropertyGroup>

--- a/Lizard/Messaging/MessageQueueListener.cs
+++ b/Lizard/Messaging/MessageQueueListener.cs
@@ -39,6 +39,7 @@ namespace Lizard.Messaging
 
             connection = factory.CreateConnection();
             channel = connection.CreateModel();
+            channel.BasicQos(0, 20, false);
 
             var args = new Dictionary<string, object?>();
             args.Add("x-message-ttl", 3600000);

--- a/Lizard/Messaging/MessageQueueListener.cs
+++ b/Lizard/Messaging/MessageQueueListener.cs
@@ -133,6 +133,7 @@ namespace Lizard.Messaging
                             };
                         }
                     }
+                    db.LogEntries.Add(entity);
                     db.SaveChanges();
                 }
 

--- a/Lizard/Migrations/20220816180306_Lizard_M1.Designer.cs
+++ b/Lizard/Migrations/20220816180306_Lizard_M1.Designer.cs
@@ -203,7 +203,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithOne("Exception")
                         .HasForeignKey("Lizard.Entities.ExceptionLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -214,7 +214,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithOne("HttpRequest")
                         .HasForeignKey("Lizard.Entities.HttpRequestLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -225,7 +225,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.HttpRequestLogEntry", "Request")
                         .WithOne("Response")
                         .HasForeignKey("Lizard.Entities.HttpResponseLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Request");
@@ -236,13 +236,13 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "InnerExceptionLogEntry")
                         .WithOne("OuterExceptionLogEntry")
                         .HasForeignKey("Lizard.Entities.InnerExceptionReference", "InnerExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "OuterExceptionLogEntry")
                         .WithOne("InnerExceptionLogEntry")
                         .HasForeignKey("Lizard.Entities.InnerExceptionReference", "OuterExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("InnerExceptionLogEntry");
@@ -255,7 +255,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.Source", "Source")
                         .WithMany()
                         .HasForeignKey("SourceID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Source");
@@ -266,7 +266,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithMany("Occurrences")
                         .HasForeignKey("LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -277,7 +277,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "ExceptionLogEntry")
                         .WithOne("StackTrace")
                         .HasForeignKey("Lizard.Entities.StackTrace", "ExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("ExceptionLogEntry");

--- a/Lizard/Migrations/20220816180306_Lizard_M1.cs
+++ b/Lizard/Migrations/20220816180306_Lizard_M1.cs
@@ -47,7 +47,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "Source",
                         principalColumn: "SourceID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -66,7 +66,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "LogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -89,7 +89,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "LogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -112,7 +112,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "LogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -132,14 +132,14 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "ExceptionLogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_InnerExceptionLogEntry_ExceptionLogEntry_OuterExceptionLogEntryID",
                         column: x => x.OuterExceptionLogEntryID,
                         principalSchema: "lizard",
                         principalTable: "ExceptionLogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -160,7 +160,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "ExceptionLogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -182,7 +182,7 @@ namespace Lizard.Migrations
                         principalSchema: "lizard",
                         principalTable: "HttpRequestLogEntry",
                         principalColumn: "LogEntryID",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateIndex(

--- a/Lizard/Migrations/LizardDbContextModelSnapshot.cs
+++ b/Lizard/Migrations/LizardDbContextModelSnapshot.cs
@@ -201,7 +201,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithOne("Exception")
                         .HasForeignKey("Lizard.Entities.ExceptionLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -212,7 +212,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithOne("HttpRequest")
                         .HasForeignKey("Lizard.Entities.HttpRequestLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -223,7 +223,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.HttpRequestLogEntry", "Request")
                         .WithOne("Response")
                         .HasForeignKey("Lizard.Entities.HttpResponseLogEntry", "LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Request");
@@ -234,13 +234,13 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "InnerExceptionLogEntry")
                         .WithOne("OuterExceptionLogEntry")
                         .HasForeignKey("Lizard.Entities.InnerExceptionReference", "InnerExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "OuterExceptionLogEntry")
                         .WithOne("InnerExceptionLogEntry")
                         .HasForeignKey("Lizard.Entities.InnerExceptionReference", "OuterExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("InnerExceptionLogEntry");
@@ -253,7 +253,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.Source", "Source")
                         .WithMany()
                         .HasForeignKey("SourceID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Source");
@@ -264,7 +264,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.LogEntry", "LogEntry")
                         .WithMany("Occurrences")
                         .HasForeignKey("LogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("LogEntry");
@@ -275,7 +275,7 @@ namespace Lizard.Migrations
                     b.HasOne("Lizard.Entities.ExceptionLogEntry", "ExceptionLogEntry")
                         .WithOne("StackTrace")
                         .HasForeignKey("Lizard.Entities.StackTrace", "ExceptionLogEntryID")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("ExceptionLogEntry");

--- a/Lizard/Program.cs
+++ b/Lizard/Program.cs
@@ -1,4 +1,5 @@
 using Lizard;
+using Lizard.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,11 +18,16 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddCheck("readiness", new ReadinessHealthCheck(builder.Configuration));
 
 var app = builder.Build();
 
 app.UseHealthChecks("/healthz");
+app.MapHealthChecks("/readyz", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions()
+{
+    Predicate = x => x.Tags.Contains("readiness")
+});
 
 var messageQueueListener = new Lizard.Messaging.MessageQueueListener(app.Configuration);
 


### PR DESCRIPTION
Changes: 
- Fixed migration with restricted foreign keys.
- Ensured client sends up a source
- `SendMessage` on client for simple messages
- RabbitMQ message prefetch set at 20 for trial.
- Added readiness health check and migration on startup.  Call to add migration has been removed.